### PR TITLE
fix: resolve jQuery prototype pollution vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Support for the following package managers (more coming soon):
 
 ![Screenshot](https://raw.githubusercontent.com/truenorth/chrome-github-boxcutter/master/screenshot_small.png)
 
-### [Download it](https://chrome.google.com/webstore/detail/github-boxcutter/knapnimomamjogbajmmoefhopnebjbff)
+### [Download it](https://chromewebstore.google.com/detail/github-boxcutter/knapnimomamjogbajmmoefhopnebjbff)
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,22 @@
 {
   "name": "github-boxcutter",
   "version": "0.0.5",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+  "packages": {
+    "": {
+      "name": "github-boxcutter",
+      "version": "0.0.5",
+      "license": "MIT",
+      "dependencies": {
+        "jquery": "^3"
+      }
+    },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "license": "MIT"
     }
   }
 }


### PR DESCRIPTION
## Summary

Resolves a prototype pollution vulnerability in jQuery (CVE-2020-11022/CVE-2020-11023) by updating from version 3.3.1 to 3.7.1.

## Changes

- Updated jQuery dependency in package-lock.json from 3.3.1 to 3.7.1

## Testing

`npm audit` shows 0 vulnerabilities after this change.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*